### PR TITLE
Add msys2 build 20190524

### DIFF
--- a/recipes/msys2/20190524/LICENSE.md
+++ b/recipes/msys2/20190524/LICENSE.md
@@ -1,0 +1,27 @@
+Copyright (c) 2013, Алексей
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/msys2/20190524/conandata.yml
+++ b/recipes/msys2/20190524/conandata.yml
@@ -1,0 +1,15 @@
+sources:
+  "20190524":
+    x86:
+      url: http://repo.msys2.org/distrib/i686/msys2-base-i686-20190524.tar.xz
+      filename: msys2-base-i686-20190524.tar.xz
+    x86_64:
+      url: http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20190524.tar.xz
+      filename: msys2-base-x86_64-20190524.tar.xz
+
+checksum:
+  "20190524":
+    x86:
+      sha256: 7a463afae8bf6ce8262f010a9a1648d056ad5cefc66d6eb69fe948c57d4ccb53
+    x86_64:
+      sha256: 168e156fa9f00d90a8445676c023c63be6e82f71487f4e2688ab5cb13b345383

--- a/recipes/msys2/20190524/conanfile.py
+++ b/recipes/msys2/20190524/conanfile.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class MSYS2Conan(ConanFile):
+    name = "msys2"
+    version = "20190524"
+    description = "MSYS2 is a software distro and building platform for Windows"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "http://www.msys2.org"
+    license = "MSYS license"
+    build_requires = "7zip/19.00"
+    short_paths = True
+    options = {"exclude_files": "ANY",  # Comma separated list of file patterns to exclude from the package
+               "packages": "ANY",  # Comma separated
+               "additional_packages": "ANY"}    # Comma separated
+    default_options = {"exclude_files": "*/link.exe",
+                       "packages": "base-devel,binutils,gcc",
+                       "additional_packages": None}
+    exports = "LICENSE.md"
+    settings = "os_build", "arch_build"
+
+    def configure(self):
+        if self.settings.os_build != "Windows":
+            raise ConanInvalidConfiguration("Only Windows supported")
+
+    def source(self):
+        # build tools have to download files in build method when the
+        # source files downloaded will be different based on architecture or OS
+        pass
+
+    def build(self):
+        arch = str(self.settings.arch_build)
+        tools.download(**self.conan_data["sources"][self.version][arch])
+        filename = self.conan_data["sources"][self.version][arch]["filename"]
+        sha256 = self.conan_data["checksum"][self.version][arch]["sha256"]
+        tools.check_sha256(filename, sha256)
+        tar_name = filename.replace(".xz", "")
+        self.run("7z.exe x {0}".format(filename))
+        self.run("7z.exe x {0}".format(tar_name))
+        os.unlink(filename)
+        os.unlink(tar_name)
+
+        msys_dir = "msys64" if self.settings.arch_build == "x86_64" else "msys32"
+
+        packages = []
+        if self.options.packages:
+            packages.extend(str(self.options.packages).split(","))
+        if self.options.additional_packages:
+            packages.extend(str(self.options.additional_packages).split(","))
+
+        with tools.chdir(os.path.join(msys_dir, "usr", "bin")):
+            for package in packages:
+                self.run('bash -l -c "pacman -S %s --noconfirm"' % package)
+
+        # create /tmp dir in order to avoid
+        # bash.exe: warning: could not find /tmp, please create!
+        tmp_dir = os.path.join(msys_dir, 'tmp')
+        if not os.path.isdir(tmp_dir):
+            os.makedirs(tmp_dir)
+        tmp_name = os.path.join(tmp_dir, 'dummy')
+        with open(tmp_name, 'a'):
+            os.utime(tmp_name, None)
+
+    def package(self):
+        msys_dir = "msys64" if self.settings.arch_build == "x86_64" else "msys32"
+        excludes = None
+        if self.options.exclude_files:
+            excludes = tuple(str(self.options.exclude_files).split(","))
+        self.copy("*", dst="bin", src=msys_dir, excludes=excludes)
+        self.copy("LICENSE.md", dst="licenses")
+
+    def package_info(self):
+        msys_root = os.path.join(self.package_folder, "bin")
+        msys_bin = os.path.join(msys_root, "usr", "bin")
+
+        self.output.info("Creating MSYS_ROOT env var : %s" % msys_root)
+        self.env_info.MSYS_ROOT = msys_root
+
+        self.output.info("Creating MSYS_BIN env var : %s" % msys_bin)
+        self.env_info.MSYS_BIN = msys_bin
+
+        self.output.info("Appending PATH env var with : " + msys_bin)
+        self.env_info.path.append(msys_bin)

--- a/recipes/msys2/20190524/test_package/conanfile.py
+++ b/recipes/msys2/20190524/test_package/conanfile.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile, tools
+import os
+
+
+class TestPackage(ConanFile):
+        
+    def test(self):
+        bash = tools.which("bash.exe")
+        
+        if bash:
+            self.output.info("using bash.exe from: " + bash)
+        else:
+            raise ConanException("No instance of bash.exe could be found on %PATH%")
+        
+        self.run('bash.exe -c ^"make --version^"')
+        self.run('bash.exe -c ^"! test -f /bin/link^"')
+        self.run('bash.exe -c ^"! test -f /usr/bin/link^"')


### PR DESCRIPTION
Specify library name and version:  **msys2/20190524**

Picked conan-io/conan-center-index#135 early for use at Datalogics. Will push this to our `conan-local` repository as `msys2/20190524@datalogics/stable` for internal use.

