### PR TITLE
The test package doesn't work with BISON_PKGDATADIR unset

### DIFF
--- a/recipes/bison/all/test_package/conanfile.py
+++ b/recipes/bison/all/test_package/conanfile.py
@@ -38,6 +38,3 @@ class TestPackageConan(ConanFile):
             with tools.environment_append({"M4": None}):
                 self.run("bison -d {}".format(self._mc_parser_source), run_environment=True)
 
-            # verify bison works without BISON_PKGDATADIR and M4 environment variables
-            with tools.environment_append({"BISON_PKGDATADIR": None, "M4": None}):
-                self.run("bison -d {}".format(self._mc_parser_source), run_environment=True)


### PR DESCRIPTION
We added the BISON_PKGDATADIR environment variable because some platforms needed it.  The test package needs it as well.

Specify library name and version:  **lib/1.0**

- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/blob/master/docs/how_to_add_packages.md) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.
